### PR TITLE
Create endpoint handler for heartbeat to periodically refresh token

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/zetkin/express-zetkin-auth#readme",
   "peerDependencies": {
-    "zetkin": "^1.2.0",
+    "zetkin": "^1.4.0",
     "express": "^4.12.0"
   }
 }


### PR DESCRIPTION
This PR adds a `heartbeat(opts)` method which creates an endpoint that can be polled to refresh tokens and update cookies when necessary (as configured).